### PR TITLE
Remove input parameter DOCKERIMAGEHASH

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,9 +17,6 @@ inputs:
   COMMITHASH:
     description: 'commithash'
     required: false
-  DOCKERIMAGEHASH:
-    description: 'docker image id'
-    required: false
   S3OBJECTVERSION:
     description: 's3 object version'
     required: false
@@ -37,7 +34,6 @@ runs:
         BUILDNUMBER: ${{ inputs.BUILDNUMBER }}
         BRANCHNAME: ${{ inputs.BRANCHNAME }}
         COMMITHASH: ${{ inputs.COMMITHASH }}
-        DOCKERIMAGEHASH: ${{ inputs.DOCKERIMAGEHASH }}
         S3OBJECTVERSION: ${{ inputs.S3OBJECTVERSION }}
         KAFKA_TOPICS_JSON: ${{ inputs.KAFKA_TOPICS_JSON }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,39 +29,11 @@ if [ -z "${COMMITHASH}" ]; then
     exit 1
 fi
 
-if [ -z "${DOCKERIMAGEHASH}" ] && [ -z "${S3OBJECTVERSION}" ] ; then
-    echo "Missing both DOCKERIMAGEHASH and S3OBJECTVERSION. Either DOCKERIMAGEHASH or S3OBJECTVERSION must be specified"
-    exit 1
-fi
-
-if [ ! -z "${DOCKERIMAGEHASH}" ] && [ ! -z "${S3OBJECTVERSION}" ] ; then
-    echo "Both DOCKERIMAGEHASH and S3OBJECTVERSION are specified. Either DOCKERIMAGEHASH or S3OBJECTVERSION must be specified, but not both. "
-    exit 1
-fi
-
-
 UNIQUEID=`cat /proc/sys/kernel/random/uuid`
 
 
 echo "variables are cleared and set"
 echo $KAFKA_TOPICS_JSON
-
-
-if [ ! -z "${DOCKERIMAGEHASH}"] ; then
-    (
-cat <<EOF
-{
-    "serviceName": "${PLANERIO_SERVICE_NAME}",
-    "staticEnvironmentName": "${PLANERIO_STATIC_ENVIRONMENT_NAME}",
-    "buildNumber": ${BUILDNUMBER},
-    "branchName": "${BRANCHNAME}",
-    "commitHash": "${COMMITHASH}",
-    "dockerImageHash": "${DOCKERIMAGEHASH}",
-    "uniqueId": "${UNIQUEID}"
-}
-EOF
-    ) > /tmp/dpl_trigger_request.json
-fi
 
 if [ ! -z "${S3OBJECTVERSION}" ] && [ -z "${KAFKA_TOPICS_JSON}" ]; then
     (
@@ -77,9 +49,7 @@ cat <<EOF
 }
 EOF
     ) > /tmp/dpl_trigger_request.json
-fi
-
-if [ ! -z "${S3OBJECTVERSION}" ] && [ ! -z "${KAFKA_TOPICS_JSON}" ]; then
+elif [ ! -z "${S3OBJECTVERSION}" ] && [ ! -z "${KAFKA_TOPICS_JSON}" ]; then
     (
 cat <<EOF
 {
@@ -90,6 +60,19 @@ cat <<EOF
     "commitHash": "${COMMITHASH}",
     "s3ObjectVersion": "${S3OBJECTVERSION}",
     "kafkaTopics": ${KAFKA_TOPICS_JSON},
+    "uniqueId": "${UNIQUEID}"
+}
+EOF
+    ) > /tmp/dpl_trigger_request.json
+else
+    (
+cat <<EOF
+{
+    "serviceName": "${PLANERIO_SERVICE_NAME}",
+    "staticEnvironmentName": "${PLANERIO_STATIC_ENVIRONMENT_NAME}",
+    "buildNumber": ${BUILDNUMBER},
+    "branchName": "${BRANCHNAME}",
+    "commitHash": "${COMMITHASH}",
     "uniqueId": "${UNIQUEID}"
 }
 EOF


### PR DESCRIPTION
As discussed with Felix and Ingmar:
we don't need to pass the parameter DOCKERIMAGEHASH into the planerio-microservice-deployment-triggerDeployment lambda.

Input validation and processing logic changed accordingly:
in the previous implementation of this GitHub Action, either a docker image hash or a S3 object version was required (but not both).
In fact, there is the use case where we want to deploy a lambda into an S3 bucket, and need a docker container for the DB migrations, so there is in fact no either/or. Also, there are of course use cases where no S3 object version needs to be specified.