### PR TITLE
PAP-151 fetch kafka topics directly from file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -35,5 +35,3 @@ runs:
         BRANCHNAME: ${{ inputs.BRANCHNAME }}
         COMMITHASH: ${{ inputs.COMMITHASH }}
         S3OBJECTVERSION: ${{ inputs.S3OBJECTVERSION }}
-        KAFKA_TOPICS_JSON: ${{ inputs.KAFKA_TOPICS_JSON }}
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,10 @@ UNIQUEID=`cat /proc/sys/kernel/random/uuid`
 
 
 echo "variables are cleared and set"
-echo $KAFKA_TOPICS_JSON
+KAFKA_TOPICS_JSON='[]'
+if [ -f planerio-kafka-consumer.json ]; then
+    KAFKA_TOPICS_JSON=$(jq -r .topicsV1 < planerio-kafka-consumer.json)
+fi
 
 if [ ! -z "${S3OBJECTVERSION}" ] && [ -z "${KAFKA_TOPICS_JSON}" ]; then
     (

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,21 +38,7 @@ if [ -f planerio-kafka-consumer.json ]; then
     KAFKA_TOPICS_JSON=$(jq -r .topicsV1 < planerio-kafka-consumer.json)
 fi
 
-if [ ! -z "${S3OBJECTVERSION}" ] && [ -z "${KAFKA_TOPICS_JSON}" ]; then
-    (
-cat <<EOF
-{
-    "serviceName": "${PLANERIO_SERVICE_NAME}",
-    "staticEnvironmentName": "${PLANERIO_STATIC_ENVIRONMENT_NAME}",
-    "buildNumber": ${BUILDNUMBER},
-    "branchName": "${BRANCHNAME}",
-    "commitHash": "${COMMITHASH}",
-    "s3ObjectVersion": "${S3OBJECTVERSION}",
-    "uniqueId": "${UNIQUEID}"
-}
-EOF
-    ) > /tmp/dpl_trigger_request.json
-elif [ ! -z "${S3OBJECTVERSION}" ] && [ ! -z "${KAFKA_TOPICS_JSON}" ]; then
+if [ ! -z "${S3OBJECTVERSION}" ]; then
     (
 cat <<EOF
 {
@@ -76,6 +62,7 @@ cat <<EOF
     "buildNumber": ${BUILDNUMBER},
     "branchName": "${BRANCHNAME}",
     "commitHash": "${COMMITHASH}",
+    "kafkaTopics": ${KAFKA_TOPICS_JSON},
     "uniqueId": "${UNIQUEID}"
 }
 EOF
@@ -143,5 +130,3 @@ echo .
 if [[ "${status}" != "SUCCEEDED" ]]; then
     exit 255
 fi
-
-


### PR DESCRIPTION
Extracting the topics from the file planerio-kafka-consumer.json in the root directory, and piping them as raw json into the variable KAFKA_TOPICS_JSON is no longer needed on the side of the caller of the planerio-public-github-action. The planerio-github-action does the whole job on its own.