### PR TITLE
fix: passing environment to the waitForE2ETests job

### DIFF
--- a/.github/workflows/waitForE2ETests.yml
+++ b/.github/workflows/waitForE2ETests.yml
@@ -31,14 +31,14 @@ jobs:
             - name: Invoke the lambda and wait until it does not return pending
               timeout-minutes: ${{ inputs.wait-timeout }}
               run: |
-                  until [[ $(aws lambda invoke --function-name cdkmetrics --cli-binary-format raw-in-base64-out --payload '{"type": "test_status", "sha": "${{ github.sha }}", "test_type": "${{ inputs.test-type }}"${{ inputs.environment && format(', \"environment\": \"{0}\"', inputs.environment) || '' }}}' /dev/stdout 2>/dev/null --no-cli-pager | jq -r '.status | select( . != null )') != "pending" ]]; do
+                  until [[ $(aws lambda invoke --function-name cdkmetrics --cli-binary-format raw-in-base64-out --payload '{"type": "test_status", "sha": "${{ github.sha }}", "test_type": "${{ inputs.test-type }}"${{ inputs.environment && format(', "environment": "{0}"', inputs.environment) || '' }}}' /dev/stdout 2>/dev/null --no-cli-pager | jq -r '.status | select( . != null )') != "pending" ]]; do
                     echo "Waiting for ${{ inputs.test-type }} tests results for ${{ github.sha }}..."
                     sleep 5
                   done
 
             - name: Check the status of the ${{ inputs.test-type }} tests and fail the workflow if tests failed
               run: |
-                  status=$(aws lambda invoke --function-name cdkmetrics --cli-binary-format raw-in-base64-out --payload '{"type": "test_status", "sha": "${{ github.sha }}", "test_type": "${{ inputs.test-type }}"${{ inputs.environment && format(', \"environment\": \"{0}\"', inputs.environment) || '' }}}' /dev/stdout 2>/dev/null --no-cli-pager | jq -r '.status | select( . != null )')
+                  status=$(aws lambda invoke --function-name cdkmetrics --cli-binary-format raw-in-base64-out --payload '{"type": "test_status", "sha": "${{ github.sha }}", "test_type": "${{ inputs.test-type }}"${{ inputs.environment && format(', "environment": "{0}"', inputs.environment) || '' }}}' /dev/stdout 2>/dev/null --no-cli-pager | jq -r '.status | select( . != null )')
                   echo "The status of the ${{ inputs.test-type }} tests is $status"
 
                   # post the link to the test run to the summary


### PR DESCRIPTION
### GenAI Contribution

#### Level of unaltered GenAI code contribution (check one):
- [ ] Low (<25%)
- [ ] Medium (25-85%)
- [ ] High (>85%)

#### GenAI Tools that contributed code to this PR (check multiple):
- [ ] Copilot
- [ ] Copilot Edits
- [ ] Copilot Workspace
- [ ] Cursor
- [ ] ChatGPT
- [ ] Gemini
- [ ] Claude
- [ ] Agentforce
- [ ] DeepSeek
- [ ] Perplexity
- [ ] Junie
- [ ] Augment Code
- [ ] JetBrains AI Assistant

<sup>If a tool is missing, check [genai-contributions](https://github.com/doctariDev/.github) for exact 
wording first, and create a PR if it is missing there as well.</sup>
<!-- END OF GenAi Contribution -->
