### PR TITLE
backmerge: add new option create-pr-if-behind

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         default: false
         description: Whether the latest version tag (beginning with "v", followed by a digit) should be included in the PR title
+      create-pr-if-behind:
+        type: boolean
+        default: false
+        description: Whether to create a PR if merge-to-branch is behind merge-from-branch, even without file differences
     secrets:
         IT_DOCTARI_BOT_TOKEN:
           required: true
@@ -67,16 +71,20 @@ jobs:
           fi
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "has_changes="$(git diff --exit-code --quiet $BRANCH_NAME "origin/${{ inputs.merge-to-branch }}"; echo $?) >> $GITHUB_OUTPUT
+          
+          # Check if merge-to-branch is behind merge-from-branch (has missing commits)
+          COMMITS_BEHIND=$(git rev-list --count "origin/${{ inputs.merge-to-branch }}..origin/${{ inputs.merge-from-branch }}")
+          echo "commits_behind=$COMMITS_BEHIND" >> $GITHUB_OUTPUT
 
       # Push the new branch to the remote repository
       - name: Push new branch
-        if: steps.cb.outputs.has_changes != '0'
+        if: steps.cb.outputs.has_changes != '0' || (inputs.create-pr-if-behind && steps.cb.outputs.commits_behind != '0')
         run: |
           git push --quiet origin :${{ steps.cb.outputs.branch_name }} || true
           git push --quiet --set-upstream origin ${{ steps.cb.outputs.branch_name }}
 
       - name: Create Pull Request (as doctari-it user)
-        if: steps.cb.outputs.has_changes != '0'
+        if: steps.cb.outputs.has_changes != '0' || (inputs.create-pr-if-behind && steps.cb.outputs.commits_behind != '0')
         id: cpr
         uses: actions/github-script@v7
         with:
@@ -115,14 +123,14 @@ jobs:
           result-encoding: string
 
       - name: Approve Pull Request (as github-actions user)
-        if: steps.cb.outputs.has_changes != '0' && inputs.approve-pr
+        if: (steps.cb.outputs.has_changes != '0' || (inputs.create-pr-if-behind && steps.cb.outputs.commits_behind != '0')) && inputs.approve-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr review --approve '${{ steps.cpr.outputs.result }}'
 
       - name: Enable Auto-Merge (as github-actions user)
-        if: steps.cb.outputs.has_changes != '0'
+        if: steps.cb.outputs.has_changes != '0' || (inputs.create-pr-if-behind && steps.cb.outputs.commits_behind != '0')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Added a new option `create-pr-if-behind`, with the following behavior: if the "merge-to" branch is behind the "merge-from" branch, then we create a mergeback PR even if there is no diff in the files. This new behavior is opt-in, ensuring backwards compatibility.

Works as expected, I tested it here: https://github.com/doctariDev/hermanns-github-playground/actions/runs/15582579293/job/43881137817

## Why do we need the change? ##

We have a branch protection so that you cannot directly push to stage without a PR. Also, we require that the feature branches of PRs are up to date. If we create a PR from stage to main, and stage is behind main, we cannot merge it. Thus we create temporary branch "stage2main" from stage, and request pull into main. But with this constellation the auto-approve GitHub action is not triggered. With the new behavior can ensure that the stage branch is not behind the main branch.

### GenAI Contribution
<!-- See https://github.com/doctariDev/genai-contributions
     DO NOT ALTER THE FOLLOWING LINES
-->
#### Level of unaltered GenAI code contribution (check one):
- [ ] Low (<25%)
- [ ] Medium (25-85%)
- [x] High (>85%)

#### GenAI Tools that contributed code to this PR (check multiple):
- [ ] Copilot
- [x] Copilot Edits
- [ ] Copilot Workspace
- [ ] Copilot Agent (Preview)
- [ ] Cursor
- [ ] JetBrains AI Assistant
- [ ] Junie
- [ ] Augment Code
- [ ] Windsurf
- [ ] Agentforce
- [ ] ChatGPT
- [ ] Gemini
- [ ] Claude
- [ ] DeepSeek
- [ ] Perplexity
<!-- Please DO NOT add new entries to the pull_request_template.md before having added them to https://github.com/doctariDev/genai-contributions -->

<sup>If a tool is missing, check [genai-contributions](https://github.com/doctariDev/genai-contributions) for exact 
wording first, and create a PR if it is missing there as well.</sup>
<!-- END OF GenAi Contribution -->
